### PR TITLE
Added public site uri to menu entry in navigation template

### DIFF
--- a/templates/navigation/sidebar-menu.html.twig
+++ b/templates/navigation/sidebar-menu.html.twig
@@ -4,7 +4,7 @@
     {{ parent() }}
     {% if checkAccess('see_pastries') %}
         <li>
-            <a href="/pastries"><i class="fa fa-cutlery fa-fw"></i> <span>{{translate('PASTRIES.LIST')}}</span></a>
+            <a href="{{site.uri.public}}/pastries"><i class="fa fa-cutlery fa-fw"></i> <span>{{translate('PASTRIES.LIST')}}</span></a>
         </li>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
I just installed the pastries sprinkle to learn more about UserFrosting.
I use a XAMPP develop environment and installed UserFrosting in a subdirectory of the web root directory.

When you click on "List of pastries" in the menu, it links to web root directory and not to the public site uri.

I changed line 7 in /template/navigation/sidebar-menu.html.twig from:

`<a href="/pastries"><i class="fa fa-cutlery fa-fw"></i> <span>{{translate('PASTRIES.LIST')}}</span></a>`

to:

`<a href="{{site.uri.public}}/pastries"><i class="fa fa-cutlery fa-fw"></i> <span>{{translate('PASTRIES.LIST')}}</span></a>`

Thanks,
Chris